### PR TITLE
Fix TypeError in switchTab function in difficult-questions.html

### DIFF
--- a/difficult-questions.html
+++ b/difficult-questions.html
@@ -998,10 +998,10 @@
             <!-- Tab Container -->
             <div class="tab-container">
                 <div class="tab-buttons">
-                    <button class="tab-btn active" onclick="switchTab('list')">
+            <button class="tab-btn active" data-tab="list" onclick="switchTab('list')">
                         📋 Danh sách câu khó
                     </button>
-                    <button class="tab-btn" onclick="switchTab('quiz')">
+            <button class="tab-btn" data-tab="quiz" onclick="switchTab('quiz')">
                         🎯 Chế độ Quiz
                     </button>
                 </div>
@@ -2234,13 +2234,15 @@
                 selectedTab.classList.add('active');
             }
             
-            // Add active class to selected tab button
-            const selectedButton = event.target;
-            selectedButton.classList.add('active');
+            // Add active class to selected tab button based on data-tab attribute
+            const selectedButton = document.querySelector(`.tab-btn[data-tab="${tabName}"]`);
+            if (selectedButton) {
+                selectedButton.classList.add('active');
+            }
             
             // If switching to quiz tab, check if there are difficult questions
             if (tabName === 'quiz') {
-                const questions = getDifficultQuestions();
+                const questions = getQuestionsFromStorage('difficultQuestions');
                 if (questions.length === 0) {
                     showNotification('Không có câu hỏi khó nào để làm quiz!', 'warning');
                 }


### PR DESCRIPTION
The `switchTab` function was throwing a `TypeError: Cannot read properties of undefined (reading 'target')` when called programmatically without a click event. This happened because it was trying to access `event.target`, but the `event` object was undefined in that context.

This change makes the function more robust by:
1. Adding `data-tab` attributes to the tab buttons for reliable identification.
2. Modifying the `switchTab` function to use `document.querySelector` with the `data-tab` attribute to find and activate the correct button, removing the dependency on the `event` object.
3. Fixing a latent bug where the function was calling an undefined function `getDifficultQuestions()`.